### PR TITLE
Attempting to fix the test failure.

### DIFF
--- a/approval_polls/views.py
+++ b/approval_polls/views.py
@@ -26,10 +26,14 @@ def index(request):
 class DetailView(generic.DetailView):
     model = Poll
     template_name = 'approval_polls/detail.html'
+    def get_queryset(self):
+        return Poll.objects.filter(pub_date__lte=timezone.now())
 
 class ResultsView(generic.DetailView):
     model = Poll
     template_name = 'approval_polls/results.html'
+    def get_queryset(self):
+        return Poll.objects.filter(pub_date__lte=timezone.now())
 
 
 @require_http_methods(["POST"])


### PR DESCRIPTION
Overrided get_queryset() in DetailView and ResultsView to return only
those polls whose published datetime is equal to or before the current
datetime.

https://github.com/electology/approval_frame/issues/37