### PR TITLE
Revert "Make the registration email unique"

### DIFF
--- a/approval_frame/urls.py
+++ b/approval_frame/urls.py
@@ -1,7 +1,5 @@
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
-from registration.forms import RegistrationFormUniqueEmail
-from registration.backends.default.views import RegistrationView
 
 # autodiscover is required only for older versions of Django
 admin.autodiscover()
@@ -9,5 +7,5 @@ admin.autodiscover()
 urlpatterns = patterns('',
     url(r'^approval_polls/', include('approval_polls.urls', namespace="approval_polls")),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^accounts/', RegistrationView.as_view(form_class=RegistrationFormUniqueEmail)),
+    url(r'^accounts/', include('registration.backends.default.urls')),
 )


### PR DESCRIPTION
Reverts electology/approval_frame#50
Does not correctly map registration urls