### PR TITLE
Added pytz(v2015.7) to requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 django==1.8.1
 django-registration-redux==1.1
 dj-static==0.0.6
+pytz==2015.7


### PR DESCRIPTION
Related to http://github.com/electology/approval_frame/issues/88
timezone.activate(tzname) requires pytz to be installed if timezone name is an argument ([docs](https://docs.djangoproject.com/en/1.8/ref/utils/#django.utils.timezone.activate))