### PR TITLE
Issue81: Create optional countdown for when a poll closes

### DIFF
--- a/approval_polls/migrations/0006_poll_show_close_date.py
+++ b/approval_polls/migrations/0006_poll_show_close_date.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('approval_polls', '0005_poll_close_date'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='poll',
+            name='show_close_date',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/approval_polls/migrations/0007_poll_show_countdown.py
+++ b/approval_polls/migrations/0007_poll_show_countdown.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('approval_polls', '0006_poll_show_close_date'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='poll',
+            name='show_countdown',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/approval_polls/models.py
+++ b/approval_polls/models.py
@@ -9,6 +9,8 @@ class Poll(models.Model):
     user = models.ForeignKey(User)
     vtype = models.IntegerField(default=2)
     close_date = models.DateTimeField('date closed', null=True, blank=True)
+    show_close_date = models.BooleanField(default=False)
+    show_countdown = models.BooleanField(default=False)
 
     def is_closed(self):
         if self.close_date:

--- a/approval_polls/static/approval_polls/detail.js
+++ b/approval_polls/static/approval_polls/detail.js
@@ -1,0 +1,46 @@
+$(function () {  
+  var convertSeconds, onZero, time_difference;
+
+  convertSeconds = function (total_seconds) {
+    var days, hours, minutes, seconds, currentTime;
+
+    days = Math.floor(total_seconds / 86400);
+    hours = Math.floor((total_seconds % 86400) / 3600);
+    minutes = Math.floor(((total_seconds % 86400) % 3600) / 60);
+    seconds = Math.floor(((total_seconds % 86400) % 3600) % 60);
+    hours = ('0' + hours).slice(-2);
+    minutes = ('0' + minutes).slice(-2);
+    seconds = ('0' + seconds).slice(-2);
+    currentTime = days + 'd:' + hours + 'h:' + minutes + 'm:' + seconds + 's';
+
+    return currentTime;
+  };
+
+  $.fn.countdown = function (callback, duration) {
+    var currentTimeString, container, countdown, message;
+
+    message = 'before poll closes';
+    currentTimeString = convertSeconds(duration);
+    container = $(this[0]).html(currentTimeString + ' ' + message);
+
+    countdown = setInterval(function () {
+      if (--duration) {
+        currentTimeString = convertSeconds(duration);
+        container.html(currentTimeString + ' ' + message);
+      }
+      else {
+        clearInterval(countdown);
+        callback.call(container); 
+      }
+    }, 1000);
+  };
+
+  onZero = function () {
+    window.location.reload();
+  };
+
+  time_difference = document.getElementById('time_difference').value;
+
+  $('#timer').countdown(onZero, Math.ceil(time_difference));
+
+});

--- a/approval_polls/templates/approval_polls/create.html
+++ b/approval_polls/templates/approval_polls/create.html
@@ -65,6 +65,12 @@
             <p>Please select a closing date and time for this poll, if any</p>
             <input id='datetimepicker' type='text' class='form-control' name='close-datetime' value='' placeholder='Poll Closing Date' style='background-color: white;' readonly>
           </div>
+          <div class='checkbox'>
+            <label><input type='checkbox' name='show-close-date' id='checkbox1' value=''>Display Poll Closing Date with this poll.</label>
+          </div>
+          <div class='checkbox'>
+            <label><input type='checkbox' name='show-countdown' id='checkbox2' value=''>Display Poll Closing Countdown with this poll.</label>
+          </div>
             </div>
           </div>
         </div>

--- a/approval_polls/templates/approval_polls/create.html
+++ b/approval_polls/templates/approval_polls/create.html
@@ -61,6 +61,7 @@
           <div class='radio'>
             <label><input type='radio' name='radio-poll-type' checked='true' value='2'>Only users with registered accounts (restricted to one ballot per user, requires login).</label>
           </div>
+          <hr>
           <div class = 'datetimepicker'>
             <p>Please select a closing date and time for this poll, if any</p>
             <input id='datetimepicker' type='text' class='form-control' name='close-datetime' value='' placeholder='Poll Closing Date' style='background-color: white;' readonly>

--- a/approval_polls/templates/approval_polls/detail.html
+++ b/approval_polls/templates/approval_polls/detail.html
@@ -49,7 +49,16 @@
 
 <div class='row-fluid top-buffer'>
   <div class='col-md-12'>
-
+    {% if poll.show_close_date and not poll.is_closed %}
+      <div class='text-center'>
+        <p class='label label-info'>Closing Date: {{ poll.close_date|date:"Y/m/d,H:i e" }}</p>
+      </div>
+    {% endif %}
+    {% if poll.show_countdown and time_difference %}
+      <div class='text-center'>
+        <p class='label label-warning' id='timer'></p>
+      </div>
+    {% endif %}
     <p class='text-center'>Creator: {{poll.user.username}}</p>
     <p class='text-center'>
       <a href='{% url 'approval_polls:results' poll.id %}'>See Results</a>
@@ -67,5 +76,55 @@
     </p>
   </div>
 </div>
+
+<script>
+
+  var convertSeconds, onZero;
+
+  convertSeconds = function (total_seconds) {
+    var days, hours, minutes, seconds, currentTime;
+
+    days = Math.floor(total_seconds / 86400);
+    hours = Math.floor((total_seconds % 86400) / 3600);
+    minutes = Math.floor(((total_seconds % 86400) % 3600) / 60);
+    seconds = Math.floor(((total_seconds % 86400) % 3600) % 60);
+    days = ('0' + days).slice(-2);
+    hours = ('0' + hours).slice(-2);
+    minutes = ('0' + minutes).slice(-2);
+    seconds = ('0' + seconds).slice(-2);
+    currentTime = days + 'd:' + hours + 'h:' + minutes + 'm:' + seconds + 's';
+
+    return currentTime;
+  };
+
+  $.fn.countdown = function (callback, duration) {
+    var currentTimeString, container, countdown, message;
+
+    message = 'before poll closes';
+    currentTimeString = convertSeconds(duration);
+    container = $(this[0]).html(currentTimeString + ' ' + message);
+
+    countdown = setInterval(function () {
+      if (--duration) {
+        currentTimeString = convertSeconds(duration);
+        container.html(currentTimeString + ' ' + message);
+      }
+      else {
+        clearInterval(countdown);
+        callback.call(container); 
+      }
+    }, 1000);
+  };
+
+  onZero = function () {
+    window.location.reload();
+  };
+
+  {% if poll.show_countdown and time_difference %}
+    $('#timer').countdown(onZero, Math.ceil({{time_difference}}));
+  {% endif %}
+
+</script>
+
 {% endblock %}
 

--- a/approval_polls/templates/approval_polls/detail.html
+++ b/approval_polls/templates/approval_polls/detail.html
@@ -54,7 +54,6 @@
 
 <div class='row-fluid top-buffer'>
   <div class='col-md-12'>
-    <hr>
     {% if poll.show_close_date %}
       <div class='text-center'>
         <p class='label label-info'>Closing Date: {{ poll.close_date|date:"N j, Y, P e" }}</p>

--- a/approval_polls/templates/approval_polls/detail.html
+++ b/approval_polls/templates/approval_polls/detail.html
@@ -1,5 +1,10 @@
 {% extends 'base.html' %}
 
+{% block head %}
+  {% load staticfiles %}
+  <script src='{% static 'approval_polls/detail.js' %}'></script>
+{% endblock %}
+
 {% block content %}
 
 <div class='row-fluid'>
@@ -49,17 +54,21 @@
 
 <div class='row-fluid top-buffer'>
   <div class='col-md-12'>
-    {% if poll.show_close_date and not poll.is_closed %}
+    <hr>
+    {% if poll.show_close_date %}
       <div class='text-center'>
-        <p class='label label-info'>Closing Date: {{ poll.close_date|date:"Y/m/d,H:i e" }}</p>
+        <p class='label label-info'>Closing Date: {{ poll.close_date|date:"N j, Y, P e" }}</p>
       </div>
     {% endif %}
     {% if poll.show_countdown and time_difference %}
       <div class='text-center'>
         <p class='label label-warning' id='timer'></p>
+        <input type='hidden' id='time_difference' value='{{ time_difference }}' readonly>
       </div>
     {% endif %}
-    <p class='text-center'>Creator: {{poll.user.username}}</p>
+    <div class='text-center form-group'>
+      <p class='label label-default'>Creator: {{poll.user.username}}</p>
+    </div>
     <p class='text-center'>
       <a href='{% url 'approval_polls:results' poll.id %}'>See Results</a>
     </p>
@@ -76,55 +85,6 @@
     </p>
   </div>
 </div>
-
-<script>
-
-  var convertSeconds, onZero;
-
-  convertSeconds = function (total_seconds) {
-    var days, hours, minutes, seconds, currentTime;
-
-    days = Math.floor(total_seconds / 86400);
-    hours = Math.floor((total_seconds % 86400) / 3600);
-    minutes = Math.floor(((total_seconds % 86400) % 3600) / 60);
-    seconds = Math.floor(((total_seconds % 86400) % 3600) % 60);
-    days = ('0' + days).slice(-2);
-    hours = ('0' + hours).slice(-2);
-    minutes = ('0' + minutes).slice(-2);
-    seconds = ('0' + seconds).slice(-2);
-    currentTime = days + 'd:' + hours + 'h:' + minutes + 'm:' + seconds + 's';
-
-    return currentTime;
-  };
-
-  $.fn.countdown = function (callback, duration) {
-    var currentTimeString, container, countdown, message;
-
-    message = 'before poll closes';
-    currentTimeString = convertSeconds(duration);
-    container = $(this[0]).html(currentTimeString + ' ' + message);
-
-    countdown = setInterval(function () {
-      if (--duration) {
-        currentTimeString = convertSeconds(duration);
-        container.html(currentTimeString + ' ' + message);
-      }
-      else {
-        clearInterval(countdown);
-        callback.call(container); 
-      }
-    }, 1000);
-  };
-
-  onZero = function () {
-    window.location.reload();
-  };
-
-  {% if poll.show_countdown and time_difference %}
-    $('#timer').countdown(onZero, Math.ceil({{time_difference}}));
-  {% endif %}
-
-</script>
 
 {% endblock %}
 

--- a/approval_polls/views.py
+++ b/approval_polls/views.py
@@ -75,6 +75,9 @@ class DetailView(generic.DetailView):
                     for option in ballot.vote_set.all():
                         checked_choices.append(option.choice)
         context['checked_choices'] = checked_choices
+        if not poll.is_closed() and poll.close_date is not None:
+            time_diff = poll.close_date - timezone.now()
+            context['time_difference'] = time_diff.total_seconds()
         return context
 
 
@@ -239,12 +242,24 @@ class CreateView(generic.View):
             else:
                 closedatetime = None
 
+            if 'show-close-date' in request.POST:
+                show_close_date = True
+            else:
+                show_close_date = False
+
+            if 'show-countdown' in request.POST:
+                show_countdown = True
+            else:
+                show_countdown = False
+
             p = Poll(
                 question=question,
                 pub_date=timezone.now(),
                 user=request.user,
                 vtype=vtype,
                 close_date=closedatetime,
+                show_close_date=show_close_date,
+                show_countdown=show_countdown,
             )
             p.save()
 


### PR DESCRIPTION
1. Added two options in the 'Poll Settings' panel to allow a user to
select if he/she wants to display the close date and/or poll countdown.
2. Depending upon the user's selections, a close date and/or a poll
countdown is displayed in the poll's detail page.