### PR TITLE
Issue 47 - Display username in the invitation email

### DIFF
--- a/approval_polls/templates/approval_polls/invitation_email_body.html
+++ b/approval_polls/templates/approval_polls/invitation_email_body.html
@@ -2,7 +2,11 @@
 
 Hi,
 <p>
-{{ poll.user.first_name }} {{ poll.user.last_name }} at {{ site.name }} has invited you to vote in the following poll that uses approval voting:
+  {{ poll.user.username }}
+    {% if poll.user.first_name or poll.user.last_name %} 
+		  ({{ poll.user.first_name }} {{ poll.user.last_name }}) 
+    {% endif %}
+  at {{ site.name }} has invited you to vote in the following poll that uses approval voting:
   <p>
     <b>{{ poll.question }}</b>
   </p>


### PR DESCRIPTION
Display username in the invitation email, when firstname and lastname are not present. 