### PR TITLE
Issue 46 - Fix a bug related to display of winner label

### DIFF
--- a/approval_polls/templates/approval_polls/results.html
+++ b/approval_polls/templates/approval_polls/results.html
@@ -12,6 +12,9 @@
   <div class='col-md-12'>
     <h4>
       {{ poll.total_votes }} vote{{ poll.total_votes|pluralize }} on {{ poll.total_ballots }} ballot{{ poll.total_ballots|pluralize}}
+      {% if poll.is_closed and poll.total_votes == 0 %}
+        <p class='small'>No votes in this poll</p>
+      {% endif %}
     </h4>
   </div>
 </div>

--- a/approval_polls/views.py
+++ b/approval_polls/views.py
@@ -134,7 +134,10 @@ class ResultsView(generic.DetailView):
         for choice in poll.choice_set.all():
             choices[choice] = choice.votes()
         maxvotes = max(choices.values())
-        leading_choices = [k for k, v in choices.items() if v == maxvotes]
+        if maxvotes == 0:
+            leading_choices = []
+        else:
+            leading_choices = [k for k, v in choices.items() if v == maxvotes]
         context['leading_choices'] = leading_choices
         return context
 


### PR DESCRIPTION
- In case no one votes in a poll, a message saying that 'No votes in
this poll' is displayed after the poll closes.
- No winner label is displayed if all choices have zero votes.