### PR TITLE
Added traceback to exception re-raising in socialauth_middleware.

### DIFF
--- a/approval_frame/middleware/socialauth_middleware.py
+++ b/approval_frame/middleware/socialauth_middleware.py
@@ -1,3 +1,5 @@
+import sys
+
 from social.apps.django_app.middleware import SocialAuthExceptionMiddleware
 from social import exceptions as social_exceptions
 from django.http import HttpResponseRedirect

--- a/approval_frame/middleware/socialauth_middleware.py
+++ b/approval_frame/middleware/socialauth_middleware.py
@@ -9,4 +9,4 @@ class SocialAuthExceptionMiddleware(SocialAuthExceptionMiddleware):
         if isinstance(exception, social_exceptions.AuthCanceled):
             return HttpResponseRedirect(reverse('auth_login'))
         else:
-            raise exception
+            raise exception, None, sys.exc_info()[2]


### PR DESCRIPTION
Really minor improvement, It only makes a difference in DEBUG mode. 

Before this code was eating the tracebacks off of exceptions that passed through it, making it harder to debug anything. This attaches a traceback to the exception on raise, so the error output will be much more useful now, instead of pointing every error to socialauth_middleware.py line 12.
